### PR TITLE
Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Allows manually triggering the test workflow. This can be useful if the package is rarely updated, and one wants to still trigger tests to check e.g. everything is fine with the latest Julia version.