### PR TITLE
Dual

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ will run the solver with default options.
 
 ## Use with JuMP
 
-> [!WARNING]
-> The values of `dual` and `objective_dual` of QPALM currently do not
-> seem to be consistent with JuMP's convention. Help is welcome to figure out the issue.
+> [!INFO]
+> For the dual values to be computed and be available with `JuMP.dual` and `JuMP.objective_dual`,
+> you need set the attribute `enable_dual_termination` before calling `JuMP.optimize!` as shown below.
 
 To use QPALM with JuMP, use `QPALM.Optimizer`:
 
@@ -52,5 +52,5 @@ To use QPALM with JuMP, use `QPALM.Optimizer`:
 using JuMP, QPALM
 model = Model(QPALM.Optimizer)
 # If duals are needed
-set_optimizer_attribute(model, "enable_dual_termination", true)
+set_attribute(model, "enable_dual_termination", true)
 ```

--- a/README.md
+++ b/README.md
@@ -51,4 +51,6 @@ To use QPALM with JuMP, use `QPALM.Optimizer`:
 ```julia
 using JuMP, QPALM
 model = Model(QPALM.Optimizer)
+# If duals are needed
+set_optimizer_attribute(model, "enable_dual_termination", true)
 ```

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -200,6 +200,12 @@ function MOI.copy_to(dest::Optimizer, src::OptimizerCache)
         options = copy(options)
         options[:verbose] = 0
     end
+    @show size(A)
+#    if size(A, 1) == 0 && haskey(options, :enable_dual_termination) && options[:enable_dual_termination]
+#        # Otherwise throws: LADEL ERROR: MATRIX (POSSIBLY) NOT FULL RANK (diagonal element of 0.000000e+00)
+#        @warn("Disabling `enable_dual_termination`, not supported for a problem with no constraint")
+#        options[:enable_dual_termination] = false
+#    end
     setup!(
         dest.model;
         Q,

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -200,12 +200,6 @@ function MOI.copy_to(dest::Optimizer, src::OptimizerCache)
         options = copy(options)
         options[:verbose] = 0
     end
-    @show size(A)
-#    if size(A, 1) == 0 && haskey(options, :enable_dual_termination) && options[:enable_dual_termination]
-#        # Otherwise throws: LADEL ERROR: MATRIX (POSSIBLY) NOT FULL RANK (diagonal element of 0.000000e+00)
-#        @warn("Disabling `enable_dual_termination`, not supported for a problem with no constraint")
-#        options[:enable_dual_termination] = false
-#    end
     setup!(
         dest.model;
         Q,

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -369,7 +369,7 @@ const _DUAL_STATUS_MAP = Dict{Int,MOI.ResultStatusCode}(
 )
 
 function MOI.get(optimizer::Optimizer, attr::MOI.DualStatus)
-    if !optimizer_has_dual || attr.result_index > MOI.get(optimizer, MOI.ResultCount())
+    if !optimizer.has_dual || attr.result_index > MOI.get(optimizer, MOI.ResultCount())
         return MOI.NO_SOLUTION
     end
     return _DUAL_STATUS_MAP[optimizer.result.info.status_val]

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -35,6 +35,7 @@ function test_runtests()
     @test model.optimizer.model.model_cache isa
           MOI.Utilities.UniversalFallback{QPALM.OptimizerCache}
     MOI.set(model, MOI.Silent(), true)
+    MOI.set(model, MOI.RawOptimizerAttribute("enable_dual_termination"), true)
     config = MOI.Test.Config(;
         atol = 1e-3,
         rtol = 1e-3,

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -35,7 +35,8 @@ function test_runtests()
     @test model.optimizer.model.model_cache isa
           MOI.Utilities.UniversalFallback{QPALM.OptimizerCache}
     MOI.set(model, MOI.Silent(), true)
-    MOI.set(model, MOI.RawOptimizerAttribute("enable_dual_termination"), true)
+    # FIXME Throws LADEL ERROR: MATRIX (POSSIBLY) NOT FULL RANK (diagonal element of 0.000000e+00)
+    #MOI.set(model, MOI.RawOptimizerAttribute("enable_dual_termination"), true)
     config = MOI.Test.Config(;
         atol = 1e-3,
         rtol = 1e-3,
@@ -44,6 +45,8 @@ function test_runtests()
             MOI.SolverVersion,
             MOI.VariableBasisStatus,
             MOI.ConstraintBasisStatus,
+            MOI.DualObjectiveValue, # FIXME
+            MOI.ConstraintDual, # FIXME
         ],
     )
     MOI.Test.runtests(

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -44,8 +44,6 @@ function test_runtests()
             MOI.SolverVersion,
             MOI.VariableBasisStatus,
             MOI.ConstraintBasisStatus,
-            MOI.DualObjectiveValue, # FIXME
-            MOI.ConstraintDual, # FIXME
         ],
     )
     MOI.Test.runtests(


### PR DESCRIPTION
It is indeed fixing the dual in some cases but with this, there are many tests that segfault. For instance, below is a simple one:
So I can't yet use it in the tests but the rest can already be merged
```julia
julia> using JuMP, QPALM

julia> model = Model(QPALM.Optimizer)
A JuMP Model
├ solver: QPALM
├ objective_sense: FEASIBILITY_SENSE
├ num_variables: 0
├ num_constraints: 0
└ Names registered in the model: none

julia> @variable(model, x)
x

julia> set_attribute(model, "enable_dual_termination", true)

julia> optimize!(model)

                  QPALM Version 1.0.0                   

Iter |   P. res   |   D. res   |  Stepsize  |  Objective  
==========================================================
LADEL ERROR: MATRIX (POSSIBLY) NOT FULL RANK (diagonal element of 0.000000e+00)

[393541] signal 11 (1): Segmentation fault
in expression starting at REPL[6]:1
ladel_dense_solve at /home/blegat/.julia/artifacts/44bd625e8d2e0ad75881f9500ddd01a52622dc49/lib/libqpalm_jll.so (unknown line)
compute_dual_objective at /home/blegat/.julia/artifacts/44bd625e8d2e0ad75881f9500ddd01a52622dc49/lib/libqpalm_jll.so (unknown line)
qpalm_solve at /home/blegat/.julia/artifacts/44bd625e8d2e0ad75881f9500ddd01a52622dc49/lib/libqpalm_jll.so (unknown line)
solve! at /home/blegat/.julia/dev/QPALM/src/wrappers.jl:306
solve! at /home/blegat/.julia/dev/QPALM/src/wrappers.jl:306 [inlined]
optimize! at /home/blegat/.julia/dev/QPALM/src/MOI_wrapper.jl:290
optimize! at /home/blegat/.julia/dev/MathOptInterface/src/MathOptInterface.jl:122 [inlined]
optimize! at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:370
unknown function (ip: 0x7f3f6d7afa12) at (unknown file)
optimize! at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/bridge_optimizer.jl:367 [inlined]
optimize! at /home/blegat/.julia/dev/MathOptInterface/src/MathOptInterface.jl:122 [inlined]
optimize! at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:370
unknown function (ip: 0x7f3f6d79f742) at (unknown file)
#optimize!#96 at /home/blegat/.julia/packages/JuMP/7eD71/src/optimizer_interface.jl:609
optimize! at /home/blegat/.julia/packages/JuMP/7eD71/src/optimizer_interface.jl:560
```